### PR TITLE
Add basic .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.venv/
+scraper.log
+.git


### PR DESCRIPTION
## Summary
- add `.dockerignore` to keep build contexts clean

## Testing
- `docker build -t forexbot:test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687934611ad88329a0e3fc6d05a2b979